### PR TITLE
서치 기본 페이지 구현 #35

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",
-    "swipejs": "^2.3.1",
     "swiper": "^11.1.14",
     "vite-plugin-svgr": "^4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",
     "swipejs": "^2.3.1",
+    "swiper": "^11.1.14",
     "vite-plugin-svgr": "^4.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       react-router-dom:
         specifier: ^6.26.2
         version: 6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      swipejs:
-        specifier: ^2.3.1
-        version: 2.3.1
       swiper:
         specifier: ^11.1.14
         version: 11.1.14
@@ -2495,10 +2492,6 @@ packages:
 
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
-
-  swipejs@2.3.1:
-    resolution: {integrity: sha512-mUL5MKSVkpQ2/CMgurNNgiKNRKcRkkD1/bfe8f2Y5MZW74E99p3zCxBrV9C7goMmBY4J8lrH3Dm0IQvaV64UEQ==}
-    engines: {node: '>=10'}
 
   swiper@11.1.14:
     resolution: {integrity: sha512-VbQLQXC04io6AoAjIUWuZwW4MSYozkcP9KjLdrsG/00Q/yiwvhz9RQyt0nHXV10hi9NVnDNy1/wv7Dzq1lkOCQ==}
@@ -5371,8 +5364,6 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-parser@2.0.4: {}
-
-  swipejs@2.3.1: {}
 
   swiper@11.1.14: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       swipejs:
         specifier: ^2.3.1
         version: 2.3.1
+      swiper:
+        specifier: ^11.1.14
+        version: 11.1.14
       vite-plugin-svgr:
         specifier: ^4.2.0
         version: 4.2.0(rollup@4.22.0)(typescript@5.6.2)(vite@5.4.6(@types/node@22.7.3))
@@ -2496,6 +2499,10 @@ packages:
   swipejs@2.3.1:
     resolution: {integrity: sha512-mUL5MKSVkpQ2/CMgurNNgiKNRKcRkkD1/bfe8f2Y5MZW74E99p3zCxBrV9C7goMmBY4J8lrH3Dm0IQvaV64UEQ==}
     engines: {node: '>=10'}
+
+  swiper@11.1.14:
+    resolution: {integrity: sha512-VbQLQXC04io6AoAjIUWuZwW4MSYozkcP9KjLdrsG/00Q/yiwvhz9RQyt0nHXV10hi9NVnDNy1/wv7Dzq1lkOCQ==}
+    engines: {node: '>= 4.7.0'}
 
   synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
@@ -5366,6 +5373,8 @@ snapshots:
   svg-parser@2.0.4: {}
 
   swipejs@2.3.1: {}
+
+  swiper@11.1.14: {}
 
   synckit@0.9.2:
     dependencies:

--- a/src/apis/data/ad.ts
+++ b/src/apis/data/ad.ts
@@ -1,0 +1,12 @@
+const ad = [
+  {
+    id: 1,
+    src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
+  },
+  {
+    id: 2,
+    src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
+  },
+];
+
+export default ad;

--- a/src/apis/data/ad.ts
+++ b/src/apis/data/ad.ts
@@ -1,4 +1,6 @@
-const ad = [
+import { Ad } from '@/types/index';
+
+const ad: Ad[] = [
   {
     id: 1,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',

--- a/src/apis/data/popularSearch.ts
+++ b/src/apis/data/popularSearch.ts
@@ -1,4 +1,6 @@
-const popularSearch = [
+import { PopularSearch } from '@/types/index';
+
+const popularSearch: PopularSearch[] = [
   { id: 1, text: '모던 아트' },
   { id: 2, text: '추상화' },
   { id: 3, text: '인상파' },

--- a/src/apis/data/popularSearch.ts
+++ b/src/apis/data/popularSearch.ts
@@ -1,0 +1,14 @@
+const popularSearch = [
+  { id: 1, text: '모던 아트' },
+  { id: 2, text: '추상화' },
+  { id: 3, text: '인상파' },
+  { id: 4, text: '인물화' },
+  { id: 5, text: '풍경화' },
+  { id: 6, text: '큐비즘' },
+  { id: 7, text: '디지털 아트' },
+  { id: 8, text: '팝 아트' },
+  { id: 9, text: '아크릴화' },
+  { id: 10, text: '수채화' },
+];
+
+export default popularSearch;

--- a/src/apis/data/searchAdList.ts
+++ b/src/apis/data/searchAdList.ts
@@ -1,6 +1,6 @@
-import { Ad } from '@/types/index';
+import { SearchAd } from '@/types/index';
 
-const ad: Ad[] = [
+const searchAdList: SearchAd[] = [
   {
     id: 1,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
@@ -11,4 +11,4 @@ const ad: Ad[] = [
   },
 ];
 
-export default ad;
+export default searchAdList;

--- a/src/apis/data/searchArtist.ts
+++ b/src/apis/data/searchArtist.ts
@@ -1,51 +1,78 @@
-import { Categories } from '@/types/index';
+import { SearchArtist } from '@/types/index';
 
-const categories: Categories[] = [
+const searchArtist: SearchArtist[] = [
   {
     id: 1,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '동양화/서양화',
+    name: '작가1',
+    totalFollowers: 120,
+    totalLikes: 250,
+    followed: true,
   },
   {
     id: 2,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '서양화/현대미술',
+    name: '작가2',
+    totalFollowers: 85,
+    totalLikes: 190,
+    followed: false,
   },
   {
     id: 3,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '민화/추상화',
+    name: '작가3',
+    totalFollowers: 95,
+    totalLikes: 170,
+    followed: true,
   },
   {
     id: 4,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '동양화/모던아트',
+    name: '작가4',
+    totalFollowers: 60,
+    totalLikes: 140,
+    followed: false,
   },
   {
     id: 5,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '서양화/클래식',
+    name: '작가5',
+    totalFollowers: 110,
+    totalLikes: 220,
+    followed: true,
   },
   {
     id: 6,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '수묵화/풍경화',
+    name: '작가6',
+    totalFollowers: 50,
+    totalLikes: 130,
+    followed: false,
   },
   {
     id: 7,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '동양화/인물화',
+    name: '작가7',
+    totalFollowers: 70,
+    totalLikes: 160,
+    followed: true,
   },
   {
     id: 8,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '서양화/정물화',
+    name: '작가8',
+    totalFollowers: 90,
+    totalLikes: 180,
+    followed: true,
   },
   {
     id: 9,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '동양화/서양화',
+    name: '작가9',
+    totalFollowers: 100,
+    totalLikes: 200,
+    followed: false,
   },
 ];
 
-export default categories;
+export default searchArtist;

--- a/src/apis/data/searchWork.ts
+++ b/src/apis/data/searchWork.ts
@@ -1,51 +1,69 @@
-import { Categories } from '@/types/index';
+import { SearchWork } from '@/types/index';
 
-const categories: Categories[] = [
+const searchWork: SearchWork[] = [
   {
     id: 1,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '동양화/서양화',
+    title: '무제',
+    artist: '김영석',
+    price: 100000,
   },
   {
     id: 2,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '서양화/현대미술',
+    title: '현대 서양화',
+    artist: '이수정',
+    price: 200000,
   },
   {
     id: 3,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '민화/추상화',
+    title: '추상 민화',
+    artist: '박민지',
+    price: 300000,
   },
   {
     id: 4,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '동양화/모던아트',
+    title: '모던 동양화',
+    artist: '최윤영',
+    price: 250000,
   },
   {
     id: 5,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '서양화/클래식',
+    title: '클래식 서양화',
+    artist: '김정민',
+    price: 150000,
   },
   {
     id: 6,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '수묵화/풍경화',
+    title: '풍경 수묵화',
+    artist: '이성현',
+    price: 350000,
   },
   {
     id: 7,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '동양화/인물화',
+    title: '인물 동양화',
+    artist: '박서윤',
+    price: 180000,
   },
   {
     id: 8,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '서양화/정물화',
+    title: '정물 서양화',
+    artist: '이혜원',
+    price: 220000,
   },
   {
     id: 9,
     src: 'https://i.pinimg.com/474x/45/37/93/4537932e76ebcc6186f86b75d9eeac87.jpg',
-    des: '동양화/서양화',
+    title: '동서양화',
+    artist: '김동욱',
+    price: 270000,
   },
 ];
 
-export default categories;
+export default searchWork;

--- a/src/components/common/Chip/index.tsx
+++ b/src/components/common/Chip/index.tsx
@@ -11,7 +11,9 @@ const Chip = ({ tag, onClick }: ChipProps) => {
   return (
     <Wrapper>
       <span># {tag}</span>
-      <CancelIcon onClick={onClick} />
+      <CancelIconButton onClick={onClick}>
+        <CancelDefault />
+      </CancelIconButton>
     </Wrapper>
   );
 };
@@ -30,13 +32,16 @@ const Wrapper = styled.div`
   justify-content: space-between;
 `;
 
-const CancelIcon = styled(CancelDefault)`
+const CancelIconButton = styled.button`
   cursor: pointer;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 15px;
+  height: 15px;
+  background-color: var(--color-white);
   transition: fill 0.3s ease;
 
-  path {
+  & svg {
+    width: 100%;
+    height: 100%;
   }
 
   &:hover {
@@ -44,6 +49,3 @@ const CancelIcon = styled(CancelDefault)`
     fill: var(--color-black);
   }
 `;
-// 이 svg가 html의 조합으로 만들어지는데
-// 이 svg 자체의 속성을 변경하고 있어서 안되었다.
-// stroke속성이랑 내부의 path의 fill을 바꾸어주니 정상적으로 나왔다.

--- a/src/components/common/Chip/index.tsx
+++ b/src/components/common/Chip/index.tsx
@@ -4,7 +4,7 @@ import CancelDefault from '@/assets/icons/cancel-default.svg?react';
 
 interface ChipProps {
   tag: string;
-  onClick: () => void; // onClick prop 추가
+  onClick: () => void;
 }
 
 const Chip = ({ tag, onClick }: ChipProps) => {
@@ -21,7 +21,6 @@ export default Chip;
 const Wrapper = styled.div`
   border: 0.05rem solid var(--color-gray-md);
   border-radius: var(--border-radius);
-  background-color: var(--color-white);
   font-size: var(--font-size-xs);
   padding: 0.6rem;
   gap: 0.6rem;
@@ -35,10 +34,16 @@ const CancelIcon = styled(CancelDefault)`
   cursor: pointer;
   width: 1.5rem;
   height: 1.5rem;
-  fill: currentColor;
   transition: fill 0.3s ease;
 
+  path {
+  }
+
   &:hover {
+    stroke: var(--color-black);
     fill: var(--color-black);
   }
 `;
+// 이 svg가 html의 조합으로 만들어지는데
+// 이 svg 자체의 속성을 변경하고 있어서 안되었다.
+// stroke속성이랑 내부의 path의 fill을 바꾸어주니 정상적으로 나왔다.

--- a/src/components/common/Chip/index.tsx
+++ b/src/components/common/Chip/index.tsx
@@ -10,7 +10,7 @@ interface ChipProps {
 const Chip = ({ tag, onClick }: ChipProps) => {
   return (
     <Wrapper>
-      <span># {tag}</span>
+      <span>{tag}</span>
       <CancelIconButton onClick={onClick}>
         <CancelDefault />
       </CancelIconButton>

--- a/src/components/common/Chip/index.tsx
+++ b/src/components/common/Chip/index.tsx
@@ -4,13 +4,14 @@ import CancelDefault from '@/assets/icons/cancel-default.svg?react';
 
 interface ChipProps {
   tag: string;
+  onClick: () => void; // onClick prop 추가
 }
 
-const Chip = ({ tag }: ChipProps) => {
+const Chip = ({ tag, onClick }: ChipProps) => {
   return (
     <Wrapper>
       <span># {tag}</span>
-      <CancelDefault style={{ width: '1.5rem', height: '1.5rem' }} />
+      <CancelIcon onClick={onClick} />
     </Wrapper>
   );
 };
@@ -28,4 +29,16 @@ const Wrapper = styled.div`
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
+`;
+
+const CancelIcon = styled(CancelDefault)`
+  cursor: pointer;
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: currentColor;
+  transition: fill 0.3s ease;
+
+  &:hover {
+    fill: var(--color-black);
+  }
 `;

--- a/src/components/common/FakeSearchBar/index.tsx
+++ b/src/components/common/FakeSearchBar/index.tsx
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled';
+
+import SearchIcon from '@/assets/icons/search.svg?react';
+import IconButton from '@/components/common/IconButton';
+import { HEADER_HEIGHT } from '@/components/layouts/Header';
+
+const SEARCH_PLACEHOLDER = '작품/작가 외 검색은 #을 붙여주세요';
+
+interface FakeSearchBarProps {
+  modalOpen: () => void;
+}
+
+const FakeSearchBar = ({ modalOpen }: FakeSearchBarProps) => {
+  return (
+    <SearchBarWrapper>
+      <InputBox onClick={modalOpen}>
+        <StyledSearchIcon />
+        <Input type="text" placeholder={SEARCH_PLACEHOLDER} />
+      </InputBox>
+      <IconButton icon="favorite-default" />
+    </SearchBarWrapper>
+  );
+};
+
+export default FakeSearchBar;
+
+const SEARCHBAR_HEIGHT = HEADER_HEIGHT;
+
+const SearchBarWrapper = styled.div`
+  position: sticky;
+  top: 0;
+  width: 100%;
+  height: ${SEARCHBAR_HEIGHT};
+  padding: 6px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+`;
+
+const InputBox = styled.div`
+  position: relative;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  flex: 1 0 0;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--color-gray-md);
+  font-size: var(--font-size-sm);
+`;
+
+const Input = styled.input`
+  width: 100%;
+  align-self: stretch;
+  margin: 0 30px 0 34px;
+  outline: none;
+  border: none;
+
+  &::placeholder {
+    color: var(--color-gray-dk);
+  }
+`;
+
+const StyledSearchIcon = styled(SearchIcon)`
+  width: 2rem;
+  height: 2rem;
+  position: absolute;
+  left: 8px;
+`;

--- a/src/components/common/PopularSearchItem/index.tsx
+++ b/src/components/common/PopularSearchItem/index.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+import { Text } from '@chakra-ui/react';
+
+interface PopularSearchItemProps {
+  text: string;
+  rank: number;
+}
+
+const PopularSearchItem = ({ text, rank }: PopularSearchItemProps) => {
+  return (
+    <Wrapper>
+      <Rank isTop3={rank <= 3}>{rank}</Rank>
+      <Text>#{text}</Text>
+    </Wrapper>
+  );
+};
+
+export default PopularSearchItem;
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 15.8rem;
+  padding: 4px;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-black, #020715);
+  font-size: var(--font-size-sm);
+  font-weight: 400;
+`;
+
+const Rank = styled.span<{ isTop3: boolean }>`
+  ${({ isTop3 }) =>
+    isTop3 &&
+    `
+    font-weight: bold;
+    text-decoration: underline;
+  `}
+`;

--- a/src/components/common/SearchModal/Ad.tsx
+++ b/src/components/common/SearchModal/Ad.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+
+import { Image, Text } from '@chakra-ui/react';
+import Grid from '@/components/styles/Grid';
+import ad from '@/apis/data/ad';
+
+const Ad = () => {
+  return (
+    <Wrapper>
+      <TitleWrapper>
+        <TitleText>
+          <RedText>요즘 뜨는</RedText> 작품
+          <p>광고</p>
+        </TitleText>
+      </TitleWrapper>
+      <Grid col={2}>
+        {ad.map((ad) => (
+          <AdImage key={ad.id} src={ad.src} />
+        ))}
+      </Grid>
+    </Wrapper>
+  );
+};
+
+export default Ad;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const TitleText = styled(Text)`
+  color: var(--color-black, #020715);
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  line-height: normal;
+`;
+
+const RedText = styled.span`
+  color: var(--color-red);
+`;
+
+const AdImage = styled(Image)`
+  width: 158px;
+`;

--- a/src/components/common/SearchModal/Ad.tsx
+++ b/src/components/common/SearchModal/Ad.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { Image, Text } from '@chakra-ui/react';
+import { Image } from '@chakra-ui/react';
 import Grid from '@/components/styles/Grid';
 import ad from '@/apis/data/ad';
 
@@ -8,10 +8,10 @@ const Ad = () => {
   return (
     <Wrapper>
       <TitleWrapper>
-        <TitleText>
+        <div>
           <RedText>요즘 뜨는</RedText> 작품
-          <p>광고</p>
-        </TitleText>
+        </div>
+        <Tab>광고</Tab>
       </TitleWrapper>
       <Grid col={2}>
         {ad.map((ad) => (
@@ -31,12 +31,12 @@ const Wrapper = styled.div`
 `;
 
 const TitleWrapper = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-`;
-
-const TitleText = styled(Text)`
+  align-items: center;
+  margin-bottom: 16px;
   color: var(--color-black, #020715);
   font-size: var(--font-size-md);
   font-weight: 700;
@@ -49,4 +49,18 @@ const RedText = styled.span`
 
 const AdImage = styled(Image)`
   width: 158px;
+`;
+
+const Tab = styled.p`
+  background: var(--color-gray-lt);
+  border-radius: 50px;
+  padding: 3px 7px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  width: 36px;
+  height: 20px;
+  font-size: var(--font-size-xs);
+  color: var(--white, #fff);
+  font-weight: 700;
 `;

--- a/src/components/common/SearchModal/PopularSearch.tsx
+++ b/src/components/common/SearchModal/PopularSearch.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled';
+import popularSearch from '@/apis/data/popularSearch';
+import PopularSearchItem from '../PopularSearchItem';
+import { Text } from '@chakra-ui/react';
+import Grid from '@/components/styles/Grid';
+
+const PopularSearch = () => {
+  const midPoint = Math.ceil(popularSearch.length / 2);
+
+  return (
+    <Wrapper>
+      <TitleWrapper>
+        <TitleText>
+          <RedText>인기</RedText> 검색어
+        </TitleText>
+      </TitleWrapper>
+      <Grid col={2} style={{ justifyItems: 'flex-start' }}>
+        <Column>
+          {popularSearch.slice(0, midPoint).map((item, index) => (
+            <PopularSearchItem key={item.id} text={item.text} rank={index + 1} />
+          ))}
+        </Column>
+        <Column>
+          {popularSearch.slice(midPoint).map((item, index) => (
+            <PopularSearchItem key={item.id} text={item.text} rank={midPoint + index + 1} />
+          ))}
+        </Column>
+      </Grid>
+    </Wrapper>
+  );
+};
+
+export default PopularSearch;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const TitleText = styled(Text)`
+  color: var(--color-black, #020715);
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  line-height: normal;
+`;
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const RedText = styled.span`
+  color: var(--color-red);
+`;

--- a/src/components/common/SearchModal/RecentSearch.tsx
+++ b/src/components/common/SearchModal/RecentSearch.tsx
@@ -1,9 +1,15 @@
 import styled from '@emotion/styled';
 import Chip from '../Chip';
 import { useState, useEffect } from 'react';
+import { Text } from '@chakra-ui/react';
 
 const RecentSearch = () => {
   const [searchArray, setSearchArray] = useState([]);
+
+  const allDelete = () => {
+    setSearchArray([]);
+    localStorage.removeItem('searchArray');
+  };
 
   const handleStoredData = (tag: string) => {
     const updatedArray = searchArray.filter((item) => item !== tag);
@@ -20,10 +26,15 @@ const RecentSearch = () => {
 
   return (
     <Wrapper>
-      <h2>최근 검색어</h2>
-      {searchArray.map((item, index) => (
-        <Chip key={index} tag={item} onClick={() => handleStoredData(item)} />
-      ))}
+      <TitleWrapper>
+        <TitleText>최근 검색어</TitleText>
+        {searchArray.length > 0 && <DelText onClick={allDelete}>모두 삭제하기</DelText>}
+      </TitleWrapper>
+      <ChipWrapper>
+        {searchArray.map((item, index) => (
+          <Chip key={index} tag={item} onClick={() => handleStoredData(item)} />
+        ))}
+      </ChipWrapper>
     </Wrapper>
   );
 };
@@ -32,5 +43,35 @@ export default RecentSearch;
 
 const Wrapper = styled.div`
   display: flex;
+  flex-direction: column;
+  padding: 16px;
+`;
+
+const ChipWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
   flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 10px;
+`;
+
+const DelText = styled(Text)`
+  color: var(--color-gray-deep, #909090);
+  text-align: right;
+  font-size: var(--font-size-sm);
+  font-weight: 400;
+  line-height: normal;
+  cursor: pointer;
+`;
+
+const TitleText = styled(Text)`
+  color: var(--color-black, #020715);
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  line-height: normal;
 `;

--- a/src/components/common/SearchModal/RecentSearch.tsx
+++ b/src/components/common/SearchModal/RecentSearch.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import Chip from '../Chip';
+import { useState, useEffect } from 'react';
+
+const RecentSearch = () => {
+  const [searchArray, setSearchArray] = useState([]);
+
+  const handleStoredData = (tag: string) => {
+    const updatedArray = searchArray.filter((item) => item !== tag);
+    setSearchArray(updatedArray);
+    localStorage.setItem('searchArray', JSON.stringify(updatedArray));
+  };
+
+  useEffect(() => {
+    const storedData = localStorage.getItem('searchArray');
+    if (storedData) {
+      setSearchArray(JSON.parse(storedData));
+    }
+  }, []);
+
+  return (
+    <Wrapper>
+      <h2>최근 검색어</h2>
+      {searchArray.map((item, index) => (
+        <Chip key={index} tag={item} onClick={() => handleStoredData(item)} />
+      ))}
+    </Wrapper>
+  );
+};
+
+export default RecentSearch;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+`;

--- a/src/components/common/SearchModal/SearchAd.tsx
+++ b/src/components/common/SearchModal/SearchAd.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled';
 
 import { Image } from '@chakra-ui/react';
 import Grid from '@/components/styles/Grid';
-import ad from '@/apis/data/ad';
+import searchAdList from '@/apis/data/searchAdList';
 
-const Ad = () => {
+const SearchAd = () => {
   return (
     <Wrapper>
       <TitleWrapper>
@@ -14,7 +14,7 @@ const Ad = () => {
         <Tab>광고</Tab>
       </TitleWrapper>
       <Grid col={2}>
-        {ad.map((ad) => (
+        {searchAdList.map((ad) => (
           <AdImage key={ad.id} src={ad.src} />
         ))}
       </Grid>
@@ -22,7 +22,7 @@ const Ad = () => {
   );
 };
 
-export default Ad;
+export default SearchAd;
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/components/common/SearchModal/index.tsx
+++ b/src/components/common/SearchModal/index.tsx
@@ -1,6 +1,9 @@
 import SearchBar from '@/components/layouts/SearchBar';
 import styled from '@emotion/styled';
 import RecentSearch from './RecentSearch';
+import HorizontalLine from '@/components/styles/HorizontalLine';
+import PopularSearch from './PopularSearch';
+import Ad from './Ad';
 
 interface SearchModalProps {
   modalClose: () => void;
@@ -9,9 +12,13 @@ interface SearchModalProps {
 const SearchModal = ({ modalClose }: SearchModalProps) => {
   return (
     <ModalWrapper>
-      <SearchBar modalClose={modalClose} />
+      <SearchBar goBack={modalClose} />
       <SearchWrapper>
         <RecentSearch />
+        <HorizontalLine />
+        <PopularSearch />
+        <HorizontalLine />
+        <Ad />
       </SearchWrapper>
     </ModalWrapper>
   );
@@ -36,5 +43,4 @@ const SearchWrapper = styled.div`
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 16px 0;
 `;

--- a/src/components/common/SearchModal/index.tsx
+++ b/src/components/common/SearchModal/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import RecentSearch from './RecentSearch';
 import HorizontalLine from '@/components/styles/HorizontalLine';
 import PopularSearch from './PopularSearch';
-import Ad from './Ad';
+import Ad from './SearchAd';
 
 interface SearchModalProps {
   modalClose: () => void;
@@ -35,7 +35,6 @@ const ModalWrapper = styled.div`
   background-color: var(--color-white);
   display: flex;
   flex-direction: column;
-  padding: 0 16px;
   z-index: 1000;
 `;
 

--- a/src/components/common/SearchModal/index.tsx
+++ b/src/components/common/SearchModal/index.tsx
@@ -1,0 +1,40 @@
+import SearchBar from '@/components/layouts/SearchBar';
+import styled from '@emotion/styled';
+import RecentSearch from './RecentSearch';
+
+interface SearchModalProps {
+  modalClose: () => void;
+}
+
+const SearchModal = ({ modalClose }: SearchModalProps) => {
+  return (
+    <ModalWrapper>
+      <SearchBar modalClose={modalClose} />
+      <SearchWrapper>
+        <RecentSearch />
+      </SearchWrapper>
+    </ModalWrapper>
+  );
+};
+
+export default SearchModal;
+
+const ModalWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--color-white);
+  display: flex;
+  flex-direction: column;
+  padding: 0 16px;
+  z-index: 1000;
+`;
+
+const SearchWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 16px 0;
+`;

--- a/src/components/layouts/NoHeaderLayout/index.tsx
+++ b/src/components/layouts/NoHeaderLayout/index.tsx
@@ -1,0 +1,18 @@
+import { Outlet } from 'react-router-dom';
+
+import FABContainer from '@/components/layouts/FAB';
+import TabBar from '@/components/layouts/TabBar';
+
+const NoHeaderLayout = () => {
+  const mode = 'seller';
+
+  return (
+    <>
+      <Outlet />
+      <FABContainer mode={mode} />
+      <TabBar />
+    </>
+  );
+};
+
+export default NoHeaderLayout;

--- a/src/components/layouts/SearchBar/index.tsx
+++ b/src/components/layouts/SearchBar/index.tsx
@@ -5,24 +5,37 @@ import CancelIcon from '@/assets/icons/cancel-filled-gray.svg?react';
 import SearchIcon from '@/assets/icons/search.svg?react';
 import IconButton from '@/components/common/IconButton';
 import { HEADER_HEIGHT } from '../Header';
+import { useNavigate } from 'react-router-dom';
 
 const SEARCH_PLACEHOLDER = '작품/작가 외 검색은 #을 붙여주세요';
 
 interface SearchBarProps {
   includeFavorite?: boolean;
+  modalClose?: () => void;
 }
 
-const SearchBar = ({ includeFavorite = false }: SearchBarProps) => {
+const SearchBar = ({ includeFavorite = false, modalClose }: SearchBarProps) => {
   const [searchWord, setSearchWord] = useState<string>('');
+  const navigate = useNavigate();
 
   const handleRemoveSearchWord = (e: React.MouseEvent) => {
     e.preventDefault();
     setSearchWord('');
   };
 
+  const activeEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && searchWord.trim()) {
+      const storedData = localStorage.getItem('searchArray');
+      const searchArray = storedData ? JSON.parse(storedData) : [];
+      const updatedArray = [searchWord, ...searchArray];
+      localStorage.setItem('searchArray', JSON.stringify(updatedArray));
+      navigate(`/results?query=${searchWord}`);
+    }
+  };
+
   return (
     <SearchBarWrapper>
-      <IconButton icon="arrow-back" />
+      <IconButton icon="arrow-back" onClick={modalClose} />
       <InputBox>
         <StyledSearchIcon />
         <Input
@@ -31,6 +44,9 @@ const SearchBar = ({ includeFavorite = false }: SearchBarProps) => {
           value={searchWord}
           onChange={(e) => {
             setSearchWord(e.target.value);
+          }}
+          onKeyDown={(e) => {
+            activeEnter(e);
           }}
         />
         {searchWord.trim().length > 0 && <CancelIconButton onClick={handleRemoveSearchWord} />}

--- a/src/components/layouts/SearchBar/index.tsx
+++ b/src/components/layouts/SearchBar/index.tsx
@@ -11,10 +11,10 @@ const SEARCH_PLACEHOLDER = '작품/작가 외 검색은 #을 붙여주세요';
 
 interface SearchBarProps {
   includeFavorite?: boolean;
-  modalClose?: () => void;
+  goBack?: () => void;
 }
 
-const SearchBar = ({ includeFavorite = false, modalClose }: SearchBarProps) => {
+const SearchBar = ({ includeFavorite = false, goBack }: SearchBarProps) => {
   const [searchWord, setSearchWord] = useState<string>('');
   const navigate = useNavigate();
 
@@ -35,7 +35,7 @@ const SearchBar = ({ includeFavorite = false, modalClose }: SearchBarProps) => {
 
   return (
     <SearchBarWrapper>
-      <IconButton icon="arrow-back" onClick={modalClose} />
+      <IconButton icon="arrow-back" onClick={goBack} />
       <InputBox>
         <StyledSearchIcon />
         <Input

--- a/src/components/styles/Grid/index.tsx
+++ b/src/components/styles/Grid/index.tsx
@@ -3,10 +3,15 @@ import styled from '@emotion/styled';
 interface GridProps {
   children: React.ReactNode;
   col: number;
+  style?: React.CSSProperties;
 }
 
-const Grid = ({ children, col }: GridProps) => {
-  return <Wrapper col={col}>{children}</Wrapper>;
+const Grid = ({ children, col, style }: GridProps) => {
+  return (
+    <Wrapper col={col} style={style}>
+      {children}
+    </Wrapper>
+  );
 };
 
 export default Grid;
@@ -14,7 +19,7 @@ export default Grid;
 const Wrapper = styled.div<{ col: number }>`
   display: grid;
   gap: ${({ col }) => (col === 2 ? '8px' : '40px 12px')};
-  grid-template-columns: ${({ col }) => (col === 2 ? '1fr 1fr' : '1fr 1fr 1fr 1fr')};
+  grid-template-columns: ${({ col }) => (col === 2 ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)')};
   justify-items: center;
   padding: ${({ col }) => (col === 2 ? '16px' : '24px 16px 32px 16px;')};
 `;

--- a/src/components/styles/HorizontalLine/index.tsx
+++ b/src/components/styles/HorizontalLine/index.tsx
@@ -1,13 +1,10 @@
 import styled from '@emotion/styled';
 
-const HorizontalLine = () => {
-  return <CustomHorizontalLine />;
-};
-
-export default HorizontalLine;
-
-const CustomHorizontalLine = styled.hr`
+const HorizontalLine = styled.hr`
   width: 100%;
+  border: none;
   height: 1px;
   background-color: var(--color-gray-lt);
 `;
+
+export default HorizontalLine;

--- a/src/pages/Categories/index.tsx
+++ b/src/pages/Categories/index.tsx
@@ -2,15 +2,25 @@ import { Text } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 
 import categories from '@/apis/data/categories';
-import SearchBar from '@/components/layouts/SearchBar';
 import Gap from '@/components/styles/Gap';
 import Grid from '@/components/styles/Grid';
 import Category from './components/CategoryItem';
+import { useState } from 'react';
+import FakeSearchBar from '@/components/common/FakeSearchBar';
+import SearchModal from '@/components/common/SearchModal';
 
 const Categories = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleModalOpen = () => {
+    setIsModalOpen(true);
+  };
+
   return (
     <Wrapper>
-      <SearchBar includeFavorite={true} />
+      <FakeSearchBar modalOpen={handleModalOpen} />
+      {isModalOpen && <SearchModal modalClose={() => setIsModalOpen(false)} />}
+
       <Grid col={4}>
         {categories.map((category) => (
           <Category key={category.id} src={category.src} des={category.des} />

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -1,5 +1,0 @@
-const Search = () => {
-  return <>Search</>;
-};
-
-export default Search;

--- a/src/pages/SearchResults/components/CategoryTabBar.tsx
+++ b/src/pages/SearchResults/components/CategoryTabBar.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+
+interface TapWrapperProps {
+  isActive: boolean;
+}
+
+const CategoryTabBar = () => {
+  const [onActive, setOnActive] = useState(0);
+
+  return (
+    <Wrapper>
+      <TapWrapper isActive={onActive === 0} onClick={() => setOnActive(0)}>
+        전체
+      </TapWrapper>
+      <TapWrapper isActive={onActive === 1} onClick={() => setOnActive(1)}>
+        작품
+      </TapWrapper>
+      <TapWrapper isActive={onActive === 2} onClick={() => setOnActive(2)}>
+        작가
+      </TapWrapper>
+    </Wrapper>
+  );
+};
+
+export default CategoryTabBar;
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 44px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 0px 16px;
+  align-items: center;
+  border-bottom: 1px solid var(--color-gray-medium);
+  background: var(--white, #fff);
+  font-size: 1.4rem;
+  text-align: center;
+`;
+
+const TapWrapper = styled.div<TapWrapperProps>`
+  width: 100%;
+  padding: 0px 8px;
+  cursor: pointer;
+  text-align: center;
+
+  color: ${({ isActive }) => (isActive ? 'var(--color-black)' : 'var(--color-gray-dk)')};
+`;

--- a/src/pages/SearchResults/components/CategoryTabBar.tsx
+++ b/src/pages/SearchResults/components/CategoryTabBar.tsx
@@ -7,18 +7,15 @@ interface TapWrapperProps {
 
 const CategoryTabBar = () => {
   const [onActive, setOnActive] = useState(0);
+  const categoryList = ['전체', '작품', '작가'];
 
   return (
     <Wrapper>
-      <TapWrapper isActive={onActive === 0} onClick={() => setOnActive(0)}>
-        전체
-      </TapWrapper>
-      <TapWrapper isActive={onActive === 1} onClick={() => setOnActive(1)}>
-        작품
-      </TapWrapper>
-      <TapWrapper isActive={onActive === 2} onClick={() => setOnActive(2)}>
-        작가
-      </TapWrapper>
+      {categoryList.map((category, index) => (
+        <TabWrapper key={index} isActive={onActive === index} onClick={() => setOnActive(index)}>
+          {category}
+        </TabWrapper>
+      ))}
     </Wrapper>
   );
 };
@@ -39,7 +36,7 @@ const Wrapper = styled.div`
   text-align: center;
 `;
 
-const TapWrapper = styled.div<TapWrapperProps>`
+const TabWrapper = styled.div<TapWrapperProps>`
   width: 100%;
   padding: 0px 8px;
   cursor: pointer;

--- a/src/pages/SearchResults/components/CategoryTabBar.tsx
+++ b/src/pages/SearchResults/components/CategoryTabBar.tsx
@@ -30,7 +30,7 @@ const Wrapper = styled.div`
   justify-content: space-between;
   padding: 0px 16px;
   align-items: center;
-  border-bottom: 1px solid var(--color-gray-medium);
+  border-bottom: 1px solid var(--color-gray-md);
   background: var(--white, #fff);
   font-size: 1.4rem;
   text-align: center;

--- a/src/pages/SearchResults/components/SwiperFrame.tsx
+++ b/src/pages/SearchResults/components/SwiperFrame.tsx
@@ -1,0 +1,63 @@
+import { SearchArtist, SearchWork } from '@/types/index';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Scrollbar } from 'swiper/modules';
+
+import styled from '@emotion/styled';
+
+import 'swiper/css';
+import 'swiper/css/scrollbar'; // Add this line to import scrollbar styles
+
+interface SwiperFrame {
+  children: SearchArtist[] | SearchWork[];
+}
+
+const SwiperFrame = ({ children }: SwiperFrame) => {
+  return (
+    <SwiperWrapper
+      modules={[Scrollbar]}
+      scrollbar={{ draggable: true }}
+      slidesPerView={3}
+      spaceBetween={40}
+    >
+      {children.map((item) => (
+        <StyledSwiperSlide key={item.id}>
+          <Image src={item.src} alt={'title' in item ? item.title : item.name} />
+          {'title' in item && (
+            <>
+              <p>제목: {item.title}</p>
+              <p>작가: {item.artist}</p>
+              <p>가격: {item.price}원</p>
+            </>
+          )}
+          {'name' in item && (
+            <>
+              <p>이름: {item.name}</p>
+              <p>팔로워 수: {item.totalFollowers}</p>
+              <p>좋아요 수: {item.totalLikes}</p>
+              <p>{item.followed ? '팔로우 중' : '팔로우 안 함'}</p>
+            </>
+          )}
+        </StyledSwiperSlide>
+      ))}
+    </SwiperWrapper>
+  );
+};
+
+export default SwiperFrame;
+
+const SwiperWrapper = styled(Swiper)`
+  width: 100%;
+  height: 223px;
+  padding: 10px 0;
+`;
+
+const StyledSwiperSlide = styled(SwiperSlide)`
+  width: 180px;
+  height: 144px;
+`;
+
+const Image = styled.img`
+  width: 140px;
+  height: 140px;
+  object-fit: cover;
+`;

--- a/src/pages/SearchResults/index.tsx
+++ b/src/pages/SearchResults/index.tsx
@@ -1,5 +1,15 @@
+import { useSearchParams } from 'react-router-dom';
+
 const SearchResults = () => {
-  return <>SearchResults</>;
+  const [searchParams] = useSearchParams();
+  const query = searchParams.get('query');
+
+  return (
+    <>
+      SearchResults
+      <h1>{query}</h1>
+    </>
+  );
 };
 
 export default SearchResults;

--- a/src/pages/SearchResults/index.tsx
+++ b/src/pages/SearchResults/index.tsx
@@ -1,13 +1,25 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import SearchBar from '@/components/layouts/SearchBar';
+import CategoryTabBar from './components/CategoryTabBar';
+import SwiperFrame from './components/SwiperFrame';
+import searchWork from '@/apis/data/searchWork';
+import searchArtist from '@/apis/data/searchArtist';
 
 const SearchResults = () => {
   const [searchParams] = useSearchParams();
   const query = searchParams.get('query');
+  const navigate = useNavigate();
+
+  const goBack = () => {
+    navigate(-1);
+  };
 
   return (
     <>
-      SearchResults
-      <h1>{query}</h1>
+      <SearchBar goBack={goBack} />
+      <CategoryTabBar /> <h1>query : {query}</h1>
+      <SwiperFrame children={searchWork} />
+      <SwiperFrame children={searchArtist} />
     </>
   );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -18,6 +18,7 @@ import SearchResults from '@/pages/SearchResults';
 import Signup from '@/pages/Signup';
 import { ProtectedRoute } from './ProtectedRoute';
 import { RouterPath } from './path';
+import NoHeaderLayout from '@/components/layouts/NoHeaderLayout';
 
 const Routes = () => {
   return <RouterProvider router={router} />;
@@ -35,10 +36,6 @@ const router = createBrowserRouter([
       {
         path: RouterPath.discover,
         element: <Discover />,
-      },
-      {
-        path: RouterPath.categories,
-        element: <Categories />,
       },
       {
         path: `${RouterPath.products}/:productId`,
@@ -89,6 +86,16 @@ const router = createBrowserRouter([
       {
         path: RouterPath.notFound,
         element: <Navigate to={RouterPath.home} />,
+      },
+    ],
+  },
+  {
+    path: RouterPath.root,
+    element: <NoHeaderLayout />,
+    children: [
+      {
+        path: RouterPath.categories,
+        element: <Categories />,
       },
     ],
   },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -14,7 +14,6 @@ import MyOrders from '@/pages/MyOrders';
 import MySales from '@/pages/MySales';
 import ProductDetails from '@/pages/ProductDetails';
 import ProductPosting from '@/pages/ProductPosting';
-import Search from '@/pages/Search';
 import SearchResults from '@/pages/SearchResults';
 import Signup from '@/pages/Signup';
 import { ProtectedRoute } from './ProtectedRoute';
@@ -40,16 +39,6 @@ const router = createBrowserRouter([
       {
         path: RouterPath.categories,
         element: <Categories />,
-      },
-      {
-        path: RouterPath.search,
-        element: <Search />,
-        children: [
-          {
-            path: RouterPath.results,
-            element: <SearchResults />,
-          },
-        ],
       },
       {
         path: `${RouterPath.products}/:productId`,
@@ -102,6 +91,10 @@ const router = createBrowserRouter([
         element: <Navigate to={RouterPath.home} />,
       },
     ],
+  },
+  {
+    path: `${RouterPath.results}`,
+    element: <SearchResults />,
   },
   {
     path: RouterPath.login,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,34 @@
 export type Mode = 'user' | 'seller';
+
+export type SearchWork = {
+  id: number;
+  src: string;
+  title: string;
+  artist: string;
+  price: number;
+};
+
+export type Ad = {
+  id: number;
+  src: string;
+};
+
+export type Categories = {
+  id: number;
+  src: string;
+  des: string;
+};
+
+export type PopularSearch = {
+  id: number;
+  text: string;
+};
+
+export type SearchArtist = {
+  id: number;
+  name: string;
+  src: string;
+  totalFollowers: number;
+  totalLikes: number;
+  followed: boolean;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@ export type SearchWork = {
   price: number;
 };
 
-export type Ad = {
+export type SearchAd = {
   id: number;
   src: string;
 };


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 기본적인 서치 기본 페이지를 구현하였습니다
- 전체적으로 구현틀을 잡아놓았고 그 안에서 할수 있는 부분들을 구현하였습니다

- search modal을 통해 전체 최근검색어, 인기검색어, 요즘뜨는 작품들을 포함하였습니다
- 그 후 검색 결과를 쿼리를 통해 가져왔고 검색 결과 페이지의 경우 위의 탭바와 siwper만 추가한 상태입니다. , 해당 부분 UI 아직 완성된 상태는 아닙니다.
- 아직 백엔드와 API 협의는 하지 않은 상태이기에 api/data안에 임시 data를 넣어놓았습니다.
---

### 📌 참고 사항

- 미구현된 UI 부분은 시험기간이 끝나면 마저 구현할 예정입니다.


---

### 🐞 현재 버그

-

---

### 🧐 질문

-

---

### ✏ Git Close
