### PR TITLE
FAB svg 색깔 바꾸기, 레이아웃 수정 #55

### DIFF
--- a/src/components/layouts/BasicLayout/index.tsx
+++ b/src/components/layouts/BasicLayout/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { Outlet } from 'react-router-dom';
 
 import FABContainer from '@/components/layouts/FAB';
@@ -8,13 +9,19 @@ const BasicLayout = () => {
   const mode = 'seller';
 
   return (
-    <>
+    <PageLayout>
       <Header mode={mode} />
       <Outlet />
       <FABContainer mode={mode} />
       <TabBar />
-    </>
+    </PageLayout>
   );
 };
 
 export default BasicLayout;
+
+const PageLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;

--- a/src/components/layouts/FAB/index.tsx
+++ b/src/components/layouts/FAB/index.tsx
@@ -88,7 +88,9 @@ const StyledScrollToTopButton = styled(StyledFAB)`
   background: var(--color-white);
 
   svg {
-    fill: var(--color-black);
+    path {
+      fill: var(--color-black);
+    }
   }
 `;
 
@@ -97,6 +99,8 @@ const StyledPostButton = styled(StyledFAB)`
   background: var(--color-black);
 
   svg {
-    fill: var(--color-white);
+    path {
+      fill: var(--color-white);
+    }
   }
 `;

--- a/src/components/layouts/FAB/index.tsx
+++ b/src/components/layouts/FAB/index.tsx
@@ -88,9 +88,7 @@ const StyledScrollToTopButton = styled(StyledFAB)`
   background: var(--color-white);
 
   svg {
-    path {
-      fill: var(--color-black);
-    }
+    color: var(--color-black);
   }
 `;
 
@@ -99,8 +97,6 @@ const StyledPostButton = styled(StyledFAB)`
   background: var(--color-black);
 
   svg {
-    path {
-      fill: var(--color-white);
-    }
+    color: var(--color-white);
   }
 `;

--- a/src/components/layouts/Header/index.tsx
+++ b/src/components/layouts/Header/index.tsx
@@ -43,7 +43,7 @@ const Header = ({ mode, title, leftSideChildren, rightSideChildren }: HeaderProp
     }
   };
 
-  return <HeaderWrapper>{renderElements()}</HeaderWrapper>;
+  return <Wrapper>{renderElements()}</Wrapper>;
 };
 
 export default Header;
@@ -51,7 +51,7 @@ export default Header;
 // styles
 export const HEADER_HEIGHT = '4.4rem';
 
-const HeaderWrapper = styled.div`
+const Wrapper = styled.header`
   position: fixed;
   top: 0;
   width: 100%;

--- a/src/components/layouts/Header/index.tsx
+++ b/src/components/layouts/Header/index.tsx
@@ -52,7 +52,7 @@ export default Header;
 export const HEADER_HEIGHT = '4.4rem';
 
 const HeaderWrapper = styled.div`
-  position: sticky;
+  position: fixed;
   top: 0;
   width: 100%;
   height: ${HEADER_HEIGHT};

--- a/src/components/layouts/TabBar/Tab.tsx
+++ b/src/components/layouts/TabBar/Tab.tsx
@@ -47,7 +47,7 @@ const StyledLink = styled(Link, {
     color: var(--color-black);
 
     svg {
-      fill: var(--color-black);
+      color: var(--color-black);
     }
   }
 

--- a/src/components/layouts/TabBar/index.tsx
+++ b/src/components/layouts/TabBar/index.tsx
@@ -38,6 +38,6 @@ const Wrapper = styled.div`
   flex-direction: row;
   background-color: var(--color-white);
   border-top: 1px solid var(--color-gray-md);
-  position: sticky;
+  position: fixed;
   bottom: 0;
 `;

--- a/src/components/layouts/TabBar/index.tsx
+++ b/src/components/layouts/TabBar/index.tsx
@@ -31,7 +31,7 @@ export default TabBar;
 
 export const TABBAR_HEIGHT = '5.4rem';
 
-const Wrapper = styled.div`
+const Wrapper = styled.nav`
   width: 100%;
   height: ${TABBAR_HEIGHT};
   display: flex;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -18,7 +18,9 @@ const Home = () => {
 export default Home;
 
 const Wrapper = styled.div`
-  min-height: calc(100vh - ${HEADER_HEIGHT} - ${TABBAR_HEIGHT});
   display: flex;
   flex-direction: column;
+  flex: 1;
+  margin: ${HEADER_HEIGHT} 0 ${TABBAR_HEIGHT} 0;
+  overflow-y: auto;
 `;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -17,7 +17,7 @@ const Home = () => {
 
 export default Home;
 
-const Wrapper = styled.div`
+const Wrapper = styled.main`
   display: flex;
   flex-direction: column;
   flex: 1;


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- svg 색깔 변경
- 베이직 레이아웃 (페이지 전체 레이아웃에 해당하는) 수정

### 📌 참고 사항

- color 속성값을 넣거나, svg 내 path 같은 태그에 직접 fill 속성값 주면 정상 작동
  1. color:
텍스트 요소(span, p)나 일부 HTML 요소(div나 button, ...)의 텍스트 색상을 지정하는 속성인데,  
SVG에서는 currentColor 지정해놓은 곳에 적용됨  
  2. fill:
SVG 내부의 도형(path, rect, circle, etc.)의 채우기 색상을 지정합니다.
즉 SVG의 벡터 그래픽 요소에 적용되어 도형 안을 채우는 색상을 지정할 때 사용한다고 함. (외곽선은 적용 X)


- 페이지 레이아웃인 basic layout을 flex로 하고, 
그 안의 자식 컴포넌트들(header, tabbar, FAB, outlet)도 모두 flex, 그리고 포지션은 fixed로 처리했습니다. <br />
부모 컴포넌트인 basic layout이 flex가 아니라서 탭바를 sticky로 두었었는데 (이때 탭바를 fixed로 두면 레이아웃 또 이상해지기 때문), 
탭바는 sticky이고, FAB는 fixed여서 둘이 어긋나서 가려졌던 것 같습니다. 
진작 레이아웃을 flex로 하지 왜 굳이 블록으로 하려고 했는지...? 저 자신도 이해 불가...

### ✏ Git Close
#55 
